### PR TITLE
Remove custom build step

### DIFF
--- a/.github/workflows/checkTypes.yml
+++ b/.github/workflows/checkTypes.yml
@@ -1,0 +1,22 @@
+name: Check Mime types
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+  schedule:
+    - cron: '0 0 * * Sun'  # every sunday at midnight
+
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+    container: mattpolzin2/idris-docker:nightly
+
+    steps:
+    - uses: actions/checkout@v3
+
+    - name: checkDiff
+      run: ./generator/checkDiff.sh

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 build
 mime.types
+.build/

--- a/apache-mime-types.ipkg
+++ b/apache-mime-types.ipkg
@@ -6,4 +6,3 @@ modules = Data.Mime.Apache
         , Data.Mime.Apache.Raw
 
 sourcedir = "src"
-prebuild = "./generator/generate.sh"

--- a/generator/checkDiff.sh
+++ b/generator/checkDiff.sh
@@ -1,0 +1,18 @@
+#! /bin/bash
+
+generatedFile=generator/NewTypes.idr
+
+sh generator/generate.sh $generatedFile
+
+reference=src/Data/Mime/Apache/Raw.idr
+
+DIFF=$(diff $reference $generatedFile)
+if [ -z $DIFF ];
+then
+    echo mime types up to date
+    exit 0;
+else
+    echo mime types mismatch >&2 ;
+    echo $(DIFF); >&2
+    exit 1;
+fi

--- a/generator/generate.sh
+++ b/generator/generate.sh
@@ -1,7 +1,10 @@
 #!/bin/sh
 
 mkdir -p src/Data/Mime/Apache
-output="src/Data/Mime/Apache/Raw.idr"
+output=$1
+if [ -z $output ] ; then
+    output="src/Data/Mime/Apache/Raw.idr"
+fi
 curl https://svn.apache.org/repos/asf/httpd/httpd/trunk/docs/conf/mime.types > mime.types
 (cd generator; idris2 -x generate_source Generator.idr) > $output
 rm mime.types


### PR DESCRIPTION
The pre-build step is a bit annoying to deal with when using package managers, so I've removed and move the check that the raw mime types are up to date in CI so that they are always up to date.